### PR TITLE
Fix googletest build on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ INCLUDEPATH = -I$(SOURCE_DIR) -Igoogletest/include
 OSFLAG :=
 ifeq ($(OS),Windows_NT)
 	OSFLAG += -D WIN32
+	CMAKEFLAGS += -G"MSYS Makefiles"
 	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
 		OSFLAG += -D AMD64
 	endif
@@ -95,7 +96,7 @@ googletest/include/gmock/gmock.h googletest/lib/libgmock_main.a: googletest/buil
 
 googletest/build/Makefile: googletest/CMakeLists.txt
 	mkdir -p googletest/build
-	cd googletest/build && cmake -DCMAKE_INSTALL_PREFIX=.. ..
+	cd googletest/build && cmake -DCMAKE_INSTALL_PREFIX=.. $(CMAKEFLAGS) ..
 
 googletest/CMakeLists.txt:
 	git clone git@github.com:google/googletest || git clone https://github.com/google/googletest


### PR DESCRIPTION
The cmake on github's windows build runner detects the visual studio
compiler and creates build files for visual studio instead of for msys2.
Change cmake invocation to select msys2 Makefiles as build system
target instead of visual studio.
Closes T1329.